### PR TITLE
Introduce onSuccess and onFailed listeners for AvatarView-Coil

### DIFF
--- a/avatarview-coil/api/avatarview-coil.api
+++ b/avatarview-coil/api/avatarview-coil.api
@@ -1,16 +1,20 @@
 public final class io/getstream/avatarview/coil/Avatar {
-	public fun <init> (Ljava/util/List;IILandroid/graphics/drawable/Drawable;)V
+	public fun <init> (Ljava/util/List;IILandroid/graphics/drawable/Drawable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()I
 	public final fun component3 ()I
 	public final fun component4 ()Landroid/graphics/drawable/Drawable;
-	public final fun copy (Ljava/util/List;IILandroid/graphics/drawable/Drawable;)Lio/getstream/avatarview/coil/Avatar;
-	public static synthetic fun copy$default (Lio/getstream/avatarview/coil/Avatar;Ljava/util/List;IILandroid/graphics/drawable/Drawable;ILjava/lang/Object;)Lio/getstream/avatarview/coil/Avatar;
+	public final fun component5 ()Lkotlin/jvm/functions/Function2;
+	public final fun component6 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Ljava/util/List;IILandroid/graphics/drawable/Drawable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Lio/getstream/avatarview/coil/Avatar;
+	public static synthetic fun copy$default (Lio/getstream/avatarview/coil/Avatar;Ljava/util/List;IILandroid/graphics/drawable/Drawable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/getstream/avatarview/coil/Avatar;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarBorderWidth ()I
 	public final fun getData ()Ljava/util/List;
 	public final fun getErrorPlaceholder ()Landroid/graphics/drawable/Drawable;
 	public final fun getMaxSectionSize ()I
+	public final fun getOnError ()Lkotlin/jvm/functions/Function2;
+	public final fun getOnSuccess ()Lkotlin/jvm/functions/Function2;
 	public final fun getTag (Ljava/lang/String;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public final fun setTagIfAbsent (Ljava/lang/String;Ljava/lang/Object;)V
@@ -44,16 +48,17 @@ public final class io/getstream/avatarview/coil/AvatarImageLoaderFactory : coil/
 
 public final class io/getstream/avatarview/coil/AvatarImageLoaderInternal {
 	public static final field INSTANCE Lio/getstream/avatarview/coil/AvatarImageLoaderInternal;
-	public final synthetic fun loadAsBitmap (Landroid/content/Context;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun loadAsBitmap (Landroid/content/Context;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun loadAsBitmap$default (Lio/getstream/avatarview/coil/AvatarImageLoaderInternal;Landroid/content/Context;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/getstream/avatarview/coil/AvatarViewExtension {
-	public static final synthetic fun loadImage (Lio/getstream/avatarview/AvatarView;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
-	public static final synthetic fun loadImage (Lio/getstream/avatarview/AvatarView;Ljava/util/List;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
-	public static final synthetic fun loadImage (Lio/getstream/avatarview/AvatarView;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun loadImage$default (Lio/getstream/avatarview/AvatarView;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun loadImage$default (Lio/getstream/avatarview/AvatarView;Ljava/util/List;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun loadImage$default (Lio/getstream/avatarview/AvatarView;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final synthetic fun loadImage (Lio/getstream/avatarview/AvatarView;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public static final synthetic fun loadImage (Lio/getstream/avatarview/AvatarView;Ljava/util/List;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public static final synthetic fun loadImage (Lio/getstream/avatarview/AvatarView;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun loadImage$default (Lio/getstream/avatarview/AvatarView;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun loadImage$default (Lio/getstream/avatarview/AvatarView;Ljava/util/List;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun loadImage$default (Lio/getstream/avatarview/AvatarView;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/getstream/avatarview/coil/ImageHeadersProvider {

--- a/avatarview-coil/src/main/kotlin/io/getstream/avatarview/coil/Avatar.kt
+++ b/avatarview-coil/src/main/kotlin/io/getstream/avatarview/coil/Avatar.kt
@@ -20,6 +20,8 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.annotation.DrawableRes
+import coil.request.ImageRequest
+import coil.request.ImageResult
 import okhttp3.HttpUrl
 import java.io.File
 
@@ -53,7 +55,13 @@ public data class Avatar(
     val avatarBorderWidth: Int,
 
     /** An error placeholder that should be shown when request failed. */
-    val errorPlaceholder: Drawable?
+    val errorPlaceholder: Drawable?,
+
+    /** A lambda function will be executed when loading succeeds. */
+    val onSuccess: (request: ImageRequest, metadata: ImageResult.Metadata) -> Unit,
+
+    /** A lambda function will be executed when loading failed. */
+    val onError: (request: ImageRequest, throwable: Throwable) -> Unit,
 ) {
     private val bagOfTags: MutableMap<String, Any> = mutableMapOf()
 

--- a/avatarview-coil/src/main/kotlin/io/getstream/avatarview/coil/AvatarBitmapFactory.kt
+++ b/avatarview-coil/src/main/kotlin/io/getstream/avatarview/coil/AvatarBitmapFactory.kt
@@ -102,7 +102,9 @@ public open class AvatarBitmapFactory(private val context: Context) {
     ): Bitmap? {
         return AvatarImageLoaderInternal.loadAsBitmap(
             context = context,
-            data = data
+            data = data,
+            onSuccess = avatar.onSuccess,
+            onError = avatar.onError
         )
     }
 

--- a/avatarview-coil/src/main/kotlin/io/getstream/avatarview/coil/AvatarImageLoaderInternal.kt
+++ b/avatarview-coil/src/main/kotlin/io/getstream/avatarview/coil/AvatarImageLoaderInternal.kt
@@ -21,6 +21,7 @@ import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import coil.loadAny
 import coil.request.ImageRequest
+import coil.request.ImageResult
 import coil.transform.CircleCropTransformation
 import coil.transform.Transformation
 import io.getstream.avatarview.AvatarView
@@ -42,6 +43,8 @@ public object AvatarImageLoaderInternal {
      *
      * @param context A context to build [ImageRequest].
      * @param data An image [data].
+     * @param onSuccess A lambda function will be executed when loading succeeds.
+     * @param onError A lambda function will be executed when loading failed.
      *
      * @return The loaded bitmap or null if the loading failed (e.g. network issues).
      */
@@ -49,10 +52,13 @@ public object AvatarImageLoaderInternal {
     public suspend fun loadAsBitmap(
         context: Context,
         data: Any?,
+        onSuccess: (request: ImageRequest, metadata: ImageResult.Metadata) -> Unit = { _, _ -> },
+        onError: (request: ImageRequest, throwable: Throwable) -> Unit = { _, _ -> },
     ): Bitmap? = withContext(Dispatchers.IO) {
         val imageResult = context.avatarImageLoader.execute(
             ImageRequest.Builder(context)
                 .headers(AvatarCoil.imageHeadersProvider.getImageRequestHeaders().toHeaders())
+                .listener(onSuccess = onSuccess, onError = onError)
                 .data(data)
                 .build()
         )

--- a/avatarview-coil/src/main/kotlin/io/getstream/avatarview/coil/AvatarViewExtension.kt
+++ b/avatarview-coil/src/main/kotlin/io/getstream/avatarview/coil/AvatarViewExtension.kt
@@ -20,6 +20,7 @@
 package io.getstream.avatarview.coil
 
 import coil.request.ImageRequest
+import coil.request.ImageResult
 import coil.transform.CircleCropTransformation
 import coil.transform.RoundedCornersTransformation
 import coil.transform.Transformation
@@ -31,7 +32,9 @@ import io.getstream.avatarview.AvatarView
  *
  * @param data An image data to be loaded.
  * @param onStart A lambda function will be executed when start requesting.
- * @param onComplete A lambda function will be executed when finish loading.
+ * @param onComplete A lambda function will be executed when loading finished.
+ * @param onSuccess A lambda function will be executed when loading succeeds.
+ * @param onError A lambda function will be executed when loading failed.
  * @param builder A receiver to be applied with the [ImageRequest.Builder].
  */
 @JvmSynthetic
@@ -39,6 +42,8 @@ public inline fun AvatarView.loadImage(
     data: Any?,
     crossinline onStart: () -> Unit = {},
     crossinline onComplete: () -> Unit = {},
+    noinline onSuccess: (request: ImageRequest, metadata: ImageResult.Metadata) -> Unit = { _, _ -> },
+    noinline onError: (request: ImageRequest, throwable: Throwable) -> Unit = { _, _ -> },
     builder: ImageRequest.Builder.() -> Unit = {}
 ) {
     loadPlaceholder()
@@ -48,7 +53,9 @@ public inline fun AvatarView.loadImage(
             data = listOf(data),
             maxSectionSize = maxSectionSize,
             avatarBorderWidth = avatarBorderWidth,
-            errorPlaceholder = errorPlaceholder
+            errorPlaceholder = errorPlaceholder,
+            onSuccess = onSuccess,
+            onError = onError
         ),
         transformation = transformation,
         onStart = onStart,
@@ -64,6 +71,8 @@ public inline fun AvatarView.loadImage(
  * @param data A list of image data to be loaded.
  * @param onStart A lambda function will be executed when start requesting.
  * @param onComplete A lambda function will be executed when finish loading.
+ * @param onSuccess A lambda function will be executed when loading succeeds.
+ * @param onError A lambda function will be executed when loading failed.
  * @param builder A receiver to be applied with the [ImageRequest.Builder].
  */
 @JvmSynthetic
@@ -71,6 +80,8 @@ public inline fun AvatarView.loadImage(
     data: List<Any?>,
     crossinline onStart: () -> Unit = {},
     crossinline onComplete: () -> Unit = {},
+    noinline onSuccess: (request: ImageRequest, metadata: ImageResult.Metadata) -> Unit = { _, _ -> },
+    noinline onError: (request: ImageRequest, throwable: Throwable) -> Unit = { _, _ -> },
     builder: ImageRequest.Builder.() -> Unit = {}
 ) {
     loadPlaceholder()
@@ -80,7 +91,9 @@ public inline fun AvatarView.loadImage(
             data = data,
             maxSectionSize = maxSectionSize,
             avatarBorderWidth = avatarBorderWidth,
-            errorPlaceholder = errorPlaceholder
+            errorPlaceholder = errorPlaceholder,
+            onSuccess = onSuccess,
+            onError = onError
         ),
         transformation = transformation,
         onStart = onStart,
@@ -96,6 +109,8 @@ public inline fun AvatarView.loadImage(
  * @param data A vararg of image data to be loaded.
  * @param onStart A lambda function will be executed when start requesting.
  * @param onComplete A lambda function will be executed when finish loading.
+ * @param onSuccess A lambda function will be executed when loading succeeds.
+ * @param onError A lambda function will be executed when loading failed.
  * @param builder A receiver to be applied with the [ImageRequest.Builder].
  */
 @JvmSynthetic
@@ -103,6 +118,8 @@ public inline fun AvatarView.loadImage(
     vararg data: Any?,
     crossinline onStart: () -> Unit = {},
     crossinline onComplete: () -> Unit = {},
+    noinline onSuccess: (request: ImageRequest, metadata: ImageResult.Metadata) -> Unit = { _, _ -> },
+    noinline onError: (request: ImageRequest, throwable: Throwable) -> Unit = { _, _ -> },
     builder: ImageRequest.Builder.() -> Unit = {}
 ) {
     loadPlaceholder()
@@ -110,6 +127,8 @@ public inline fun AvatarView.loadImage(
         data = data.toList(),
         onStart = onStart,
         onComplete = onComplete,
+        onSuccess = onSuccess,
+        onError = onError,
         builder = builder
     )
 }

--- a/avatarview-stream-integration/src/main/kotlin/io/getstream/avatarview/stream/integration/AvatarViewStreamIntegration.kt
+++ b/avatarview-stream-integration/src/main/kotlin/io/getstream/avatarview/stream/integration/AvatarViewStreamIntegration.kt
@@ -50,7 +50,9 @@ public fun AvatarView.setUserData(
             data = listOf(user.model),
             maxSectionSize = maxSectionSize,
             avatarBorderWidth = avatarBorderWidth,
-            errorPlaceholder = errorPlaceholder
+            errorPlaceholder = errorPlaceholder,
+            onSuccess = { _, _ -> },
+            onError = { _, _ -> },
         ).also {
             it.putInitialStylesOnBag(this, user)
         }
@@ -78,7 +80,9 @@ public fun AvatarView.setChannelData(channel: Channel, errorPlaceholder: Drawabl
                     data = otherUsers.map { it.model },
                     maxSectionSize = maxSectionSize,
                     avatarBorderWidth = avatarBorderWidth,
-                    errorPlaceholder = errorPlaceholder
+                    errorPlaceholder = errorPlaceholder,
+                    onSuccess = { _, _ -> },
+                    onError = { _, _ -> },
                 ).also {
                     it.putInitialStylesOnBag(this@setChannelData, channel)
                 }

--- a/buildSrc/src/main/kotlin/io/getstream/avatarview/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/avatarview/Dependencies.kt
@@ -1,8 +1,8 @@
 package io.getstream.avatarview
 
 object Versions {
-    internal const val ANDROID_GRADLE_PLUGIN = "7.1.0-beta04"
-    internal const val ANDROID_GRADLE_SPOTLESS = "5.15.0"
+    internal const val ANDROID_GRADLE_PLUGIN = "7.1.0-beta05"
+    internal const val ANDROID_GRADLE_SPOTLESS = "6.1.0"
     internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
     internal const val KOTLIN = "1.6.0"
     public const val KOTLIN_GRADLE_KTLINT = "0.41.0"


### PR DESCRIPTION
### 🎯 Goal
Introduce `onSuccess` and `onFailed` listeners for **AvatarView-Coil**.

### 🛠 Implementation details
- Added new `onSuccess` and `onFailed` listeners for observing the image loading states.

### ✍️ Explain examples
```kotlin
avatarView1.loadImage(
        cats.take(1),
        onSuccess = { _, _ ->
            // do something..
        },
        onError = { _, _ ->
            avatarView1.avatarInitials = "AA"
        }
)
```