### PR TITLE
Update Kotlin to 1.6.21

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/avatarview/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/avatarview/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     internal const val ANDROID_GRADLE_PLUGIN = "7.2.0"
     internal const val ANDROID_GRADLE_SPOTLESS = "6.6.1"
     internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
-    internal const val KOTLIN = "1.6.10"
+    internal const val KOTLIN = "1.6.21"
     internal const val KOTLIN_GRADLE_DOKKA = "1.6.10"
     internal const val KOTLIN_BINARY_VALIDATOR = "0.10.1"
     internal const val KOTLIN_COROUTINE = "1.6.0"


### PR DESCRIPTION
### 🎯 Goal
Update Kotlin to `1.6.21`.