### PR TITLE
Bump Stream SDK to 5.4.0

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/avatarview/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/avatarview/Dependencies.kt
@@ -17,7 +17,7 @@ object Versions {
     internal const val COIL = "2.1.0"
     internal const val GLIDE = "4.13.2"
 
-    internal const val STREAM_CHAT_SDK = "5.3.1"
+    internal const val STREAM_CHAT_SDK = "5.4.0"
 }
 
 object Dependencies {


### PR DESCRIPTION
### 🎯 Goal
Bump Stream SDK to 5.4.0.