### PR TITLE
Update AGP to 7.3.0 and Kotlin to 1.7.20

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/avatarview/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/avatarview/Dependencies.kt
@@ -1,13 +1,13 @@
 package io.getstream.avatarview
 
 object Versions {
-    internal const val ANDROID_GRADLE_PLUGIN = "7.2.1"
+    internal const val ANDROID_GRADLE_PLUGIN = "7.3.0"
     internal const val ANDROID_GRADLE_SPOTLESS = "6.7.0"
     internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
-    internal const val KOTLIN = "1.7.0"
-    internal const val KOTLIN_GRADLE_DOKKA = "1.7.0"
-    internal const val KOTLIN_BINARY_VALIDATOR = "0.11.0"
-    internal const val KOTLIN_COROUTINE = "1.6.3"
+    internal const val KOTLIN = "1.7.20"
+    internal const val KOTLIN_GRADLE_DOKKA = "1.7.10"
+    internal const val KOTLIN_BINARY_VALIDATOR = "0.11.1"
+    internal const val KOTLIN_COROUTINE = "1.6.4"
 
     internal const val MATERIAL = "1.6.0"
     internal const val ANDROIDX_APPCOMPAT = "1.4.0"


### PR DESCRIPTION
### 🎯 Goal
Update AGP to 7.3.0 and Kotlin to 1.7.20.